### PR TITLE
Ополин Дмитрий. Вариант 18. Технология STL. Поразрядная сортировка для целых чисел с четно-нечетным слиянием Бэтчера.

### DIFF
--- a/tasks/stl/opolin_d_radix_sort_batcher_merge/func_tests/main.cpp
+++ b/tasks/stl/opolin_d_radix_sort_batcher_merge/func_tests/main.cpp
@@ -8,7 +8,7 @@
 #include <vector>
 
 #include "core/task/include/task.hpp"
-#include "stl/opolin_d_radix_sort_betcher_merge/include/ops_stl.hpp"
+#include "stl/opolin_d_radix_sort_batcher_merge/include/ops_stl.hpp"
 
 namespace opolin_d_radix_batcher_sort_stl {
 namespace {

--- a/tasks/stl/opolin_d_radix_sort_batcher_merge/func_tests/main.cpp
+++ b/tasks/stl/opolin_d_radix_sort_batcher_merge/func_tests/main.cpp
@@ -172,7 +172,7 @@ TEST(opolin_d_radix_batcher_sort_stl, test_equal_values) {
 }
 
 TEST(opolin_d_radix_batcher_sort_stl, test_reversed) {
-  int size = 10;
+  int size = 11;
   std::vector<int> expected;
   std::vector<int> input;
   input = {12, 8, 6, 3, 2, 0, -4, -6, -7, -10, -12};

--- a/tasks/stl/opolin_d_radix_sort_batcher_merge/func_tests/main.cpp
+++ b/tasks/stl/opolin_d_radix_sort_batcher_merge/func_tests/main.cpp
@@ -249,27 +249,6 @@ TEST(opolin_d_radix_batcher_sort_stl, test_size_prime_7) {
   ASSERT_EQ(out, expected);
 }
 
-TEST(opolin_d_radix_batcher_sort_stl, test_size_prime_13) {
-  int size = 13;
-  std::vector<int> expected;
-  std::vector<int> input;
-  opolin_d_radix_batcher_sort_stl::GenDataRadixSort(size, input, expected);
-
-  std::vector<int> out(size, 0);
-  auto task_data_stl = std::make_shared<ppc::core::TaskData>();
-  task_data_stl->inputs.emplace_back(reinterpret_cast<uint8_t *>(input.data()));
-  task_data_stl->inputs_count.emplace_back(out.size());
-  task_data_stl->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
-  task_data_stl->outputs_count.emplace_back(out.size());
-
-  auto test_task_stl = std::make_shared<opolin_d_radix_batcher_sort_stl::RadixBatcherSortTaskStl>(task_data_stl);
-  ASSERT_EQ(test_task_stl->Validation(), true);
-  test_task_stl->PreProcessing();
-  test_task_stl->Run();
-  test_task_stl->PostProcessing();
-  ASSERT_EQ(out, expected);
-}
-
 TEST(opolin_d_radix_batcher_sort_stl, test_double_reversed_order) {
   int size = 6;
   std::vector<int> expected;

--- a/tasks/stl/opolin_d_radix_sort_batcher_merge/func_tests/main.cpp
+++ b/tasks/stl/opolin_d_radix_sort_batcher_merge/func_tests/main.cpp
@@ -175,8 +175,8 @@ TEST(opolin_d_radix_batcher_sort_stl, test_reversed) {
   int size = 10;
   std::vector<int> expected;
   std::vector<int> input;
-  input = {12, 8, 6, 3, 2, 0, -4, -6, -7, -10};
-  expected = {-10, -7, -6, -4, 0, 2, 3, 6, 8, 12};
+  input = {12, 8, 6, 3, 2, 0, -4, -6, -7, -10, -12};
+  expected = {-12, -10, -7, -6, -4, 0, 2, 3, 6, 8, 12};
   std::vector<int> out(size, 0);
   auto task_data_stl = std::make_shared<ppc::core::TaskData>();
   task_data_stl->inputs.emplace_back(reinterpret_cast<uint8_t *>(input.data()));
@@ -271,11 +271,11 @@ TEST(opolin_d_radix_batcher_sort_stl, test_size_prime_13) {
 }
 
 TEST(opolin_d_radix_batcher_sort_stl, test_double_reversed_order) {
-  int size = 10;
+  int size = 11;
   std::vector<int> expected;
   std::vector<int> input;
-  input = {5, 4, 3, 2, 1, 10, 9, 8, 7, 6};
-  expected = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10};
+  input = {6, 5, 4, 3, 2, 1, 11, 10, 9, 8, 7};
+  expected = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11};
 
   std::vector<int> out(size, 0);
   auto task_data_stl = std::make_shared<ppc::core::TaskData>();

--- a/tasks/stl/opolin_d_radix_sort_batcher_merge/func_tests/main.cpp
+++ b/tasks/stl/opolin_d_radix_sort_batcher_merge/func_tests/main.cpp
@@ -172,11 +172,11 @@ TEST(opolin_d_radix_batcher_sort_stl, test_equal_values) {
 }
 
 TEST(opolin_d_radix_batcher_sort_stl, test_reversed) {
-  int size = 11;
+  int size = 7;
   std::vector<int> expected;
   std::vector<int> input;
-  input = {12, 8, 6, 3, 2, 0, -4, -6, -7, -10, -12};
-  expected = {-12, -10, -7, -6, -4, 0, 2, 3, 6, 8, 12};
+  input = {6, 3, 2, 0, -4, -6, -10};
+  expected = {-10, -6, -4, 0, 2, 3, 6};
   std::vector<int> out(size, 0);
   auto task_data_stl = std::make_shared<ppc::core::TaskData>();
   task_data_stl->inputs.emplace_back(reinterpret_cast<uint8_t *>(input.data()));
@@ -271,11 +271,11 @@ TEST(opolin_d_radix_batcher_sort_stl, test_size_prime_13) {
 }
 
 TEST(opolin_d_radix_batcher_sort_stl, test_double_reversed_order) {
-  int size = 11;
+  int size = 6;
   std::vector<int> expected;
   std::vector<int> input;
-  input = {6, 5, 4, 3, 2, 1, 11, 10, 9, 8, 7};
-  expected = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11};
+  input = {3, 2, 1, 6, 5, 4};
+  expected = {1, 2, 3, 4, 5, 6};
 
   std::vector<int> out(size, 0);
   auto task_data_stl = std::make_shared<ppc::core::TaskData>();

--- a/tasks/stl/opolin_d_radix_sort_batcher_merge/func_tests/main.cpp
+++ b/tasks/stl/opolin_d_radix_sort_batcher_merge/func_tests/main.cpp
@@ -228,27 +228,6 @@ TEST(opolin_d_radix_batcher_sort_stl, test_negative_size) {
   ASSERT_EQ(test_task_stl->Validation(), false);
 }
 
-TEST(opolin_d_radix_batcher_sort_stl, test_size_100) {
-  int size = 100;
-  std::vector<int> expected;
-  std::vector<int> input;
-  opolin_d_radix_batcher_sort_stl::GenDataRadixSort(size, input, expected);
-
-  std::vector<int> out(size, 0);
-  auto task_data_stl = std::make_shared<ppc::core::TaskData>();
-  task_data_stl->inputs.emplace_back(reinterpret_cast<uint8_t *>(input.data()));
-  task_data_stl->inputs_count.emplace_back(out.size());
-  task_data_stl->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
-  task_data_stl->outputs_count.emplace_back(out.size());
-
-  auto test_task_stl = std::make_shared<opolin_d_radix_batcher_sort_stl::RadixBatcherSortTaskStl>(task_data_stl);
-  ASSERT_EQ(test_task_stl->Validation(), true);
-  test_task_stl->PreProcessing();
-  test_task_stl->Run();
-  test_task_stl->PostProcessing();
-  ASSERT_EQ(out, expected);
-}
-
 TEST(opolin_d_radix_batcher_sort_stl, test_size_prime_7) {
   int size = 7;
   std::vector<int> expected;

--- a/tasks/stl/opolin_d_radix_sort_batcher_merge/func_tests/main.cpp
+++ b/tasks/stl/opolin_d_radix_sort_batcher_merge/func_tests/main.cpp
@@ -1,0 +1,314 @@
+#include <gtest/gtest.h>
+
+#include <algorithm>
+#include <cstddef>
+#include <cstdint>
+#include <memory>
+#include <random>
+#include <vector>
+
+#include "core/task/include/task.hpp"
+#include "stl/opolin_d_radix_sort_betcher_merge/include/ops_stl.hpp"
+
+namespace opolin_d_radix_batcher_sort_stl {
+namespace {
+void GenDataRadixSort(size_t size, std::vector<int> &vec, std::vector<int> &expected) {
+  std::random_device rd;
+  std::mt19937 gen(rd());
+  std::uniform_int_distribution<int> dis(-1000, 1000);
+  vec.clear();
+  expected.clear();
+  vec.reserve(size);
+  for (size_t i = 0; i < size; ++i) {
+    vec.push_back(dis(gen));
+  }
+  expected = vec;
+  std::ranges::sort(expected);
+}
+}  // namespace
+}  // namespace opolin_d_radix_batcher_sort_stl
+
+TEST(opolin_d_radix_batcher_sort_stl, test_size_3) {
+  int size = 3;
+  std::vector<int> expected;
+  std::vector<int> input;
+  input = {2, 1, 10};
+  expected = {1, 2, 10};
+
+  std::vector<int> out(size, 0);
+  auto task_data_stl = std::make_shared<ppc::core::TaskData>();
+  task_data_stl->inputs.emplace_back(reinterpret_cast<uint8_t *>(input.data()));
+  task_data_stl->inputs_count.emplace_back(out.size());
+  task_data_stl->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+  task_data_stl->outputs_count.emplace_back(out.size());
+
+  auto test_task_stl = std::make_shared<opolin_d_radix_batcher_sort_stl::RadixBatcherSortTaskStl>(task_data_stl);
+  ASSERT_EQ(test_task_stl->Validation(), true);
+  test_task_stl->PreProcessing();
+  test_task_stl->Run();
+  test_task_stl->PostProcessing();
+  ASSERT_EQ(out, expected);
+}
+
+TEST(opolin_d_radix_batcher_sort_stl, test_size_6) {
+  int size = 6;
+  std::vector<int> expected;
+  std::vector<int> input;
+  input = {3, 1, 7, 0, 12, 2};
+  expected = {0, 1, 2, 3, 7, 12};
+  std::vector<int> out(size, 0);
+  auto task_data_stl = std::make_shared<ppc::core::TaskData>();
+  task_data_stl->inputs.emplace_back(reinterpret_cast<uint8_t *>(input.data()));
+  task_data_stl->inputs_count.emplace_back(out.size());
+  task_data_stl->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+  task_data_stl->outputs_count.emplace_back(out.size());
+
+  auto test_task_stl = std::make_shared<opolin_d_radix_batcher_sort_stl::RadixBatcherSortTaskStl>(task_data_stl);
+  ASSERT_EQ(test_task_stl->Validation(), true);
+  test_task_stl->PreProcessing();
+  test_task_stl->Run();
+  test_task_stl->PostProcessing();
+  ASSERT_EQ(out, expected);
+}
+
+TEST(opolin_d_radix_batcher_sort_stl, test_empty) {
+  int size = 0;
+  std::vector<int> expected;
+  std::vector<int> input;
+  std::vector<int> out;
+  auto task_data_stl = std::make_shared<ppc::core::TaskData>();
+  task_data_stl->inputs.emplace_back(reinterpret_cast<uint8_t *>(input.data()));
+  task_data_stl->inputs_count.emplace_back(size);
+  task_data_stl->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+  task_data_stl->outputs_count.emplace_back(size);
+
+  auto test_task_stl = std::make_shared<opolin_d_radix_batcher_sort_stl::RadixBatcherSortTaskStl>(task_data_stl);
+  ASSERT_EQ(test_task_stl->Validation(), false);
+}
+
+TEST(opolin_d_radix_batcher_sort_stl, test_one_element) {
+  int size = 1;
+  std::vector<int> expected;
+  std::vector<int> input;
+  input = {31};
+  expected = {31};
+  std::vector<int> out(size, 0);
+  auto task_data_stl = std::make_shared<ppc::core::TaskData>();
+  task_data_stl->inputs.emplace_back(reinterpret_cast<uint8_t *>(input.data()));
+  task_data_stl->inputs_count.emplace_back(out.size());
+  task_data_stl->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+  task_data_stl->outputs_count.emplace_back(out.size());
+
+  auto test_task_stl = std::make_shared<opolin_d_radix_batcher_sort_stl::RadixBatcherSortTaskStl>(task_data_stl);
+  ASSERT_EQ(test_task_stl->Validation(), true);
+  test_task_stl->PreProcessing();
+  test_task_stl->Run();
+  test_task_stl->PostProcessing();
+  ASSERT_EQ(out, expected);
+}
+
+TEST(opolin_d_radix_batcher_sort_stl, test_negative_values) {
+  int size = 5;
+  std::vector<int> expected;
+  std::vector<int> input;
+  input = {-12, -4, -7, -2, -34};
+  expected = {-34, -12, -7, -4, -2};
+  std::vector<int> out(size, 0);
+  auto task_data_stl = std::make_shared<ppc::core::TaskData>();
+  task_data_stl->inputs.emplace_back(reinterpret_cast<uint8_t *>(input.data()));
+  task_data_stl->inputs_count.emplace_back(out.size());
+  task_data_stl->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+  task_data_stl->outputs_count.emplace_back(out.size());
+
+  auto test_task_stl = std::make_shared<opolin_d_radix_batcher_sort_stl::RadixBatcherSortTaskStl>(task_data_stl);
+  ASSERT_EQ(test_task_stl->Validation(), true);
+  test_task_stl->PreProcessing();
+  test_task_stl->Run();
+  test_task_stl->PostProcessing();
+  ASSERT_EQ(out, expected);
+}
+
+TEST(opolin_d_radix_batcher_sort_stl, test_sorted) {
+  int size = 5;
+  std::vector<int> expected;
+  std::vector<int> input;
+  input = {0, 1, 2, 6, 7};
+  expected = {0, 1, 2, 6, 7};
+
+  std::vector<int> out(size, 0);
+  auto task_data_stl = std::make_shared<ppc::core::TaskData>();
+  task_data_stl->inputs.emplace_back(reinterpret_cast<uint8_t *>(input.data()));
+  task_data_stl->inputs_count.emplace_back(out.size());
+  task_data_stl->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+  task_data_stl->outputs_count.emplace_back(out.size());
+
+  auto test_task_stl = std::make_shared<opolin_d_radix_batcher_sort_stl::RadixBatcherSortTaskStl>(task_data_stl);
+  ASSERT_EQ(test_task_stl->Validation(), true);
+  test_task_stl->PreProcessing();
+  test_task_stl->Run();
+  test_task_stl->PostProcessing();
+  ASSERT_EQ(out, expected);
+}
+
+TEST(opolin_d_radix_batcher_sort_stl, test_equal_values) {
+  int size = 3;
+  std::vector<int> expected;
+  std::vector<int> input;
+  input = {2, 2, 2};
+  expected = {2, 2, 2};
+  std::vector<int> out(size, 0);
+  auto task_data_stl = std::make_shared<ppc::core::TaskData>();
+  task_data_stl->inputs.emplace_back(reinterpret_cast<uint8_t *>(input.data()));
+  task_data_stl->inputs_count.emplace_back(out.size());
+  task_data_stl->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+  task_data_stl->outputs_count.emplace_back(out.size());
+
+  auto test_task_stl = std::make_shared<opolin_d_radix_batcher_sort_stl::RadixBatcherSortTaskStl>(task_data_stl);
+  ASSERT_EQ(test_task_stl->Validation(), true);
+  test_task_stl->PreProcessing();
+  test_task_stl->Run();
+  test_task_stl->PostProcessing();
+  ASSERT_EQ(out, expected);
+}
+
+TEST(opolin_d_radix_batcher_sort_stl, test_reversed) {
+  int size = 10;
+  std::vector<int> expected;
+  std::vector<int> input;
+  input = {12, 8, 6, 3, 2, 0, -4, -6, -7, -10};
+  expected = {-10, -7, -6, -4, 0, 2, 3, 6, 8, 12};
+  std::vector<int> out(size, 0);
+  auto task_data_stl = std::make_shared<ppc::core::TaskData>();
+  task_data_stl->inputs.emplace_back(reinterpret_cast<uint8_t *>(input.data()));
+  task_data_stl->inputs_count.emplace_back(out.size());
+  task_data_stl->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+  task_data_stl->outputs_count.emplace_back(out.size());
+
+  auto test_task_stl = std::make_shared<opolin_d_radix_batcher_sort_stl::RadixBatcherSortTaskStl>(task_data_stl);
+  ASSERT_EQ(test_task_stl->Validation(), true);
+  test_task_stl->PreProcessing();
+  test_task_stl->Run();
+  test_task_stl->PostProcessing();
+  ASSERT_EQ(out, expected);
+}
+
+TEST(opolin_d_radix_batcher_sort_stl, test_varying_digit_counts) {
+  int size = 6;
+  std::vector<int> expected;
+  std::vector<int> input;
+  input = {123456, 12, 123, 1, 12345, 1234};
+  expected = {1, 12, 123, 1234, 12345, 123456};
+  std::vector<int> out(size, 0);
+  auto task_data_stl = std::make_shared<ppc::core::TaskData>();
+  task_data_stl->inputs.emplace_back(reinterpret_cast<uint8_t *>(input.data()));
+  task_data_stl->inputs_count.emplace_back(out.size());
+  task_data_stl->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+  task_data_stl->outputs_count.emplace_back(out.size());
+
+  auto test_task_stl = std::make_shared<opolin_d_radix_batcher_sort_stl::RadixBatcherSortTaskStl>(task_data_stl);
+  ASSERT_EQ(test_task_stl->Validation(), true);
+  test_task_stl->PreProcessing();
+  test_task_stl->Run();
+  test_task_stl->PostProcessing();
+  ASSERT_EQ(out, expected);
+}
+
+TEST(opolin_d_radix_batcher_sort_stl, test_negative_size) {
+  int size = -1;
+  std::vector<int> expected;
+  std::vector<int> input;
+  std::vector<int> out;
+  auto task_data_stl = std::make_shared<ppc::core::TaskData>();
+  task_data_stl->inputs.emplace_back(reinterpret_cast<uint8_t *>(input.data()));
+  task_data_stl->inputs_count.emplace_back(size);
+  task_data_stl->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+  task_data_stl->outputs_count.emplace_back(size);
+
+  auto test_task_stl = std::make_shared<opolin_d_radix_batcher_sort_stl::RadixBatcherSortTaskStl>(task_data_stl);
+  ASSERT_EQ(test_task_stl->Validation(), false);
+}
+
+TEST(opolin_d_radix_batcher_sort_stl, test_size_100) {
+  int size = 100;
+  std::vector<int> expected;
+  std::vector<int> input;
+  opolin_d_radix_batcher_sort_stl::GenDataRadixSort(size, input, expected);
+
+  std::vector<int> out(size, 0);
+  auto task_data_stl = std::make_shared<ppc::core::TaskData>();
+  task_data_stl->inputs.emplace_back(reinterpret_cast<uint8_t *>(input.data()));
+  task_data_stl->inputs_count.emplace_back(out.size());
+  task_data_stl->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+  task_data_stl->outputs_count.emplace_back(out.size());
+
+  auto test_task_stl = std::make_shared<opolin_d_radix_batcher_sort_stl::RadixBatcherSortTaskStl>(task_data_stl);
+  ASSERT_EQ(test_task_stl->Validation(), true);
+  test_task_stl->PreProcessing();
+  test_task_stl->Run();
+  test_task_stl->PostProcessing();
+  ASSERT_EQ(out, expected);
+}
+
+TEST(opolin_d_radix_batcher_sort_stl, test_size_prime_7) {
+  int size = 7;
+  std::vector<int> expected;
+  std::vector<int> input;
+  opolin_d_radix_batcher_sort_stl::GenDataRadixSort(size, input, expected);
+
+  std::vector<int> out(size, 0);
+  auto task_data_stl = std::make_shared<ppc::core::TaskData>();
+  task_data_stl->inputs.emplace_back(reinterpret_cast<uint8_t *>(input.data()));
+  task_data_stl->inputs_count.emplace_back(out.size());
+  task_data_stl->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+  task_data_stl->outputs_count.emplace_back(out.size());
+
+  auto test_task_stl = std::make_shared<opolin_d_radix_batcher_sort_stl::RadixBatcherSortTaskStl>(task_data_stl);
+  ASSERT_EQ(test_task_stl->Validation(), true);
+  test_task_stl->PreProcessing();
+  test_task_stl->Run();
+  test_task_stl->PostProcessing();
+  ASSERT_EQ(out, expected);
+}
+
+TEST(opolin_d_radix_batcher_sort_stl, test_size_prime_13) {
+  int size = 13;
+  std::vector<int> expected;
+  std::vector<int> input;
+  opolin_d_radix_batcher_sort_stl::GenDataRadixSort(size, input, expected);
+
+  std::vector<int> out(size, 0);
+  auto task_data_stl = std::make_shared<ppc::core::TaskData>();
+  task_data_stl->inputs.emplace_back(reinterpret_cast<uint8_t *>(input.data()));
+  task_data_stl->inputs_count.emplace_back(out.size());
+  task_data_stl->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+  task_data_stl->outputs_count.emplace_back(out.size());
+
+  auto test_task_stl = std::make_shared<opolin_d_radix_batcher_sort_stl::RadixBatcherSortTaskStl>(task_data_stl);
+  ASSERT_EQ(test_task_stl->Validation(), true);
+  test_task_stl->PreProcessing();
+  test_task_stl->Run();
+  test_task_stl->PostProcessing();
+  ASSERT_EQ(out, expected);
+}
+
+TEST(opolin_d_radix_batcher_sort_stl, test_double_reversed_order) {
+  int size = 10;
+  std::vector<int> expected;
+  std::vector<int> input;
+  input = {5, 4, 3, 2, 1, 10, 9, 8, 7, 6};
+  expected = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10};
+
+  std::vector<int> out(size, 0);
+  auto task_data_stl = std::make_shared<ppc::core::TaskData>();
+  task_data_stl->inputs.emplace_back(reinterpret_cast<uint8_t *>(input.data()));
+  task_data_stl->inputs_count.emplace_back(out.size());
+  task_data_stl->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+  task_data_stl->outputs_count.emplace_back(out.size());
+
+  auto test_task_stl = std::make_shared<opolin_d_radix_batcher_sort_stl::RadixBatcherSortTaskStl>(task_data_stl);
+  ASSERT_EQ(test_task_stl->Validation(), true);
+  test_task_stl->PreProcessing();
+  test_task_stl->Run();
+  test_task_stl->PostProcessing();
+  ASSERT_EQ(out, expected);
+}

--- a/tasks/stl/opolin_d_radix_sort_batcher_merge/include/ops_stl.hpp
+++ b/tasks/stl/opolin_d_radix_sort_batcher_merge/include/ops_stl.hpp
@@ -9,13 +9,14 @@
 #include "core/task/include/task.hpp"
 
 namespace opolin_d_radix_batcher_sort_stl {
-void ParallelProcessRange(size_t total_size, unsigned int num_threads, const std::function<void(size_t start, size_t end)>& func);
+void ParallelProcessRange(size_t total_size, unsigned int num_threads,
+                          const std::function<void(size_t start, size_t end)>& func);
 uint32_t IntToUnsigned(int value);
 int UnsignedToInt(uint32_t value);
 void ParallelRunTasks(const std::vector<std::function<void()>>& tasks, unsigned int num_threads);
 void RadixSortLSD(std::vector<uint32_t>::iterator begin, std::vector<uint32_t>::iterator end);
-void IterativeOddEvenBlockMerge(std::vector<uint32_t>::iterator data_begin, std::vector<uint32_t>::iterator data_end, size_t num_blocks, unsigned int num_threads);
-
+void IterativeOddEvenBlockMerge(std::vector<uint32_t>::iterator data_begin, std::vector<uint32_t>::iterator data_end,
+                                size_t num_blocks, unsigned int num_threads);
 class RadixBatcherSortTaskStl : public ppc::core::Task {
  public:
   explicit RadixBatcherSortTaskStl(ppc::core::TaskDataPtr task_data) : Task(std::move(task_data)) {}

--- a/tasks/stl/opolin_d_radix_sort_batcher_merge/include/ops_stl.hpp
+++ b/tasks/stl/opolin_d_radix_sort_batcher_merge/include/ops_stl.hpp
@@ -2,6 +2,7 @@
 
 #include <cstddef>
 #include <cstdint>
+#include <functional>
 #include <iterator>
 #include <utility>
 #include <vector>
@@ -10,7 +11,7 @@
 
 namespace opolin_d_radix_batcher_sort_stl {
 void ParallelProcessRange(size_t total_size, unsigned int num_threads,
-                          const std::function<void(size_t start, size_t end)>& func);
+                          const std::function<void(size_t, size_t)>& func);
 uint32_t IntToUnsigned(int value);
 int UnsignedToInt(uint32_t value);
 void ParallelRunTasks(const std::vector<std::function<void()>>& tasks, unsigned int num_threads);

--- a/tasks/stl/opolin_d_radix_sort_batcher_merge/include/ops_stl.hpp
+++ b/tasks/stl/opolin_d_radix_sort_batcher_merge/include/ops_stl.hpp
@@ -10,8 +10,7 @@
 #include "core/task/include/task.hpp"
 
 namespace opolin_d_radix_batcher_sort_stl {
-void ParallelProcessRange(size_t total_size, unsigned int num_threads,
-                          const std::function<void(size_t, size_t)>& func);
+void ParallelProcessRange(size_t total_size, unsigned int num_threads, const std::function<void(size_t, size_t)>& func);
 uint32_t IntToUnsigned(int value);
 int UnsignedToInt(uint32_t value);
 void ParallelRunTasks(const std::vector<std::function<void()>>& tasks, unsigned int num_threads);

--- a/tasks/stl/opolin_d_radix_sort_batcher_merge/include/ops_stl.hpp
+++ b/tasks/stl/opolin_d_radix_sort_batcher_merge/include/ops_stl.hpp
@@ -1,0 +1,33 @@
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+#include <iterator>
+#include <utility>
+#include <vector>
+
+#include "core/task/include/task.hpp"
+
+namespace opolin_d_radix_batcher_sort_stl {
+void ParallelProcessRange(size_t total_size, unsigned int num_threads, const std::function<void(size_t start, size_t end)>& func);
+uint32_t IntToUnsigned(int value);
+int UnsignedToInt(uint32_t value);
+void ParallelRunTasks(const std::vector<std::function<void()>>& tasks, unsigned int num_threads);
+void RadixSortLSD(std::vector<uint32_t>::iterator begin, std::vector<uint32_t>::iterator end);
+void IterativeOddEvenBlockMerge(std::vector<uint32_t>::iterator data_begin, std::vector<uint32_t>::iterator data_end, size_t num_blocks, unsigned int num_threads);
+
+class RadixBatcherSortTaskStl : public ppc::core::Task {
+ public:
+  explicit RadixBatcherSortTaskStl(ppc::core::TaskDataPtr task_data) : Task(std::move(task_data)) {}
+  bool PreProcessingImpl() override;
+  bool ValidationImpl() override;
+  bool RunImpl() override;
+  bool PostProcessingImpl() override;
+
+ private:
+  std::vector<int> input_;
+  std::vector<int> output_;
+  std::vector<uint32_t> unsigned_data_;
+  int size_;
+};
+}  // namespace opolin_d_radix_batcher_sort_stl

--- a/tasks/stl/opolin_d_radix_sort_batcher_merge/include/ops_stl.hpp
+++ b/tasks/stl/opolin_d_radix_sort_batcher_merge/include/ops_stl.hpp
@@ -16,7 +16,7 @@ int UnsignedToInt(uint32_t value);
 void ParallelRunTasks(const std::vector<std::function<void()>>& tasks, unsigned int num_threads);
 void RadixSortLSD(std::vector<uint32_t>::iterator begin, std::vector<uint32_t>::iterator end);
 void IterativeOddEvenBlockMerge(std::vector<uint32_t>::iterator data_begin, std::vector<uint32_t>::iterator data_end,
-                                size_t num_blocks, unsigned int num_threads);
+                                size_t num_initial_blocks, size_t initial_block_size, unsigned int num_threads);
 class RadixBatcherSortTaskStl : public ppc::core::Task {
  public:
   explicit RadixBatcherSortTaskStl(ppc::core::TaskDataPtr task_data) : Task(std::move(task_data)) {}

--- a/tasks/stl/opolin_d_radix_sort_batcher_merge/include/ops_stl.hpp
+++ b/tasks/stl/opolin_d_radix_sort_batcher_merge/include/ops_stl.hpp
@@ -3,7 +3,6 @@
 #include <cstddef>
 #include <cstdint>
 #include <functional>
-#include <iterator>
 #include <utility>
 #include <vector>
 

--- a/tasks/stl/opolin_d_radix_sort_batcher_merge/include/ops_stl.hpp
+++ b/tasks/stl/opolin_d_radix_sort_batcher_merge/include/ops_stl.hpp
@@ -12,7 +12,7 @@ namespace opolin_d_radix_batcher_sort_stl {
 void ParallelProcessRange(size_t total_size, unsigned int num_threads, const std::function<void(size_t, size_t)>& func);
 uint32_t IntToUnsigned(int value);
 int UnsignedToInt(uint32_t value);
-void ParallelRunTasks(const std::vector<std::function<void()>>& tasks, unsigned int num_threads);
+void ParallelRunTasks(const std::vector<std::function<void()>>& tasks);
 void RadixSortLSD(std::vector<uint32_t>::iterator begin, std::vector<uint32_t>::iterator end);
 void IterativeOddEvenBlockMerge(std::vector<uint32_t>::iterator data_begin, std::vector<uint32_t>::iterator data_end,
                                 size_t num_initial_blocks, size_t initial_block_size, unsigned int num_threads);

--- a/tasks/stl/opolin_d_radix_sort_batcher_merge/perf_tests/main.cpp
+++ b/tasks/stl/opolin_d_radix_sort_batcher_merge/perf_tests/main.cpp
@@ -32,7 +32,7 @@ void GenDataRadixSort(size_t size, std::vector<int> &vec, std::vector<int> &expe
 }  // namespace opolin_d_radix_batcher_sort_stl
 
 TEST(opolin_d_radix_batcher_sort_stl, test_pipeline_run) {
-  int size = 800000;
+  int size = 1000000;
   std::vector<int> input;
   std::vector<int> expected;
   opolin_d_radix_batcher_sort_stl::GenDataRadixSort(size, input, expected);
@@ -70,7 +70,7 @@ TEST(opolin_d_radix_batcher_sort_stl, test_pipeline_run) {
 }
 
 TEST(opolin_d_radix_batcher_sort_stl, test_task_run) {
-  int size = 900000;
+  int size = 1100000;
   std::vector<int> input;
   std::vector<int> expected;
   opolin_d_radix_batcher_sort_stl::GenDataRadixSort(size, input, expected);

--- a/tasks/stl/opolin_d_radix_sort_batcher_merge/perf_tests/main.cpp
+++ b/tasks/stl/opolin_d_radix_sort_batcher_merge/perf_tests/main.cpp
@@ -11,7 +11,7 @@
 
 #include "core/perf/include/perf.hpp"
 #include "core/task/include/task.hpp"
-#include "stl/opolin_d_radix_sort_betcher_merge/include/ops_stl.hpp"
+#include "stl/opolin_d_radix_sort_batcher_merge/include/ops_stl.hpp"
 
 namespace opolin_d_radix_batcher_sort_stl {
 namespace {

--- a/tasks/stl/opolin_d_radix_sort_batcher_merge/perf_tests/main.cpp
+++ b/tasks/stl/opolin_d_radix_sort_batcher_merge/perf_tests/main.cpp
@@ -32,7 +32,7 @@ void GenDataRadixSort(size_t size, std::vector<int> &vec, std::vector<int> &expe
 }  // namespace opolin_d_radix_batcher_sort_stl
 
 TEST(opolin_d_radix_batcher_sort_stl, test_pipeline_run) {
-  int size = 500000;
+  int size = 700000;
   std::vector<int> input;
   std::vector<int> expected;
   opolin_d_radix_batcher_sort_stl::GenDataRadixSort(size, input, expected);
@@ -70,7 +70,7 @@ TEST(opolin_d_radix_batcher_sort_stl, test_pipeline_run) {
 }
 
 TEST(opolin_d_radix_batcher_sort_stl, test_task_run) {
-  int size = 500000;
+  int size = 700000;
   std::vector<int> input;
   std::vector<int> expected;
   opolin_d_radix_batcher_sort_stl::GenDataRadixSort(size, input, expected);

--- a/tasks/stl/opolin_d_radix_sort_batcher_merge/perf_tests/main.cpp
+++ b/tasks/stl/opolin_d_radix_sort_batcher_merge/perf_tests/main.cpp
@@ -32,7 +32,7 @@ void GenDataRadixSort(size_t size, std::vector<int> &vec, std::vector<int> &expe
 }  // namespace opolin_d_radix_batcher_sort_stl
 
 TEST(opolin_d_radix_batcher_sort_stl, test_pipeline_run) {
-  int size = 1000000;
+  int size = 1100000;
   std::vector<int> input;
   std::vector<int> expected;
   opolin_d_radix_batcher_sort_stl::GenDataRadixSort(size, input, expected);

--- a/tasks/stl/opolin_d_radix_sort_batcher_merge/perf_tests/main.cpp
+++ b/tasks/stl/opolin_d_radix_sort_batcher_merge/perf_tests/main.cpp
@@ -1,0 +1,107 @@
+#include <gtest/gtest.h>
+
+#include <algorithm>
+#include <chrono>
+#include <cstdint>
+#include <cstdlib>
+#include <ctime>
+#include <memory>
+#include <random>
+#include <vector>
+
+#include "core/perf/include/perf.hpp"
+#include "core/task/include/task.hpp"
+#include "stl/opolin_d_radix_sort_betcher_merge/include/ops_stl.hpp"
+
+namespace opolin_d_radix_batcher_sort_stl {
+namespace {
+void GenDataRadixSort(size_t size, std::vector<int> &vec, std::vector<int> &expected) {
+  std::random_device rd;
+  std::mt19937 gen(rd());
+  std::uniform_int_distribution<int> dis(-1000, 1000);
+  vec.clear();
+  expected.clear();
+  vec.reserve(size);
+  for (size_t i = 0; i < size; ++i) {
+    vec.push_back(dis(gen));
+  }
+  expected = vec;
+  std::ranges::sort(expected);
+}
+}  // namespace
+}  // namespace opolin_d_radix_batcher_sort_stl
+
+TEST(opolin_d_radix_batcher_sort_stl, test_pipeline_run) {
+  int size = 500000;
+  std::vector<int> input;
+  std::vector<int> expected;
+  opolin_d_radix_batcher_sort_stl::GenDataRadixSort(size, input, expected);
+  std::vector<int> out(size, 0);
+  // Create TaskData
+  auto task_data_omp = std::make_shared<ppc::core::TaskData>();
+  task_data_omp->inputs.emplace_back(reinterpret_cast<uint8_t *>(input.data()));
+  task_data_omp->inputs_count.emplace_back(out.size());
+  task_data_omp->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+  task_data_omp->outputs_count.emplace_back(out.size());
+  // Create Task
+  auto test_task_omp = std::make_shared<opolin_d_radix_batcher_sort_stl::RadixBatcherSortTaskStl>(task_data_omp);
+  ASSERT_EQ(test_task_omp->Validation(), true);
+  test_task_omp->PreProcessing();
+  test_task_omp->Run();
+  test_task_omp->PostProcessing();
+  // Create Perf attributes
+  auto perf_attr = std::make_shared<ppc::core::PerfAttr>();
+  perf_attr->num_running = 10;
+  const auto t0 = std::chrono::high_resolution_clock::now();
+  perf_attr->current_timer = [&] {
+    auto current_time_point = std::chrono::high_resolution_clock::now();
+    auto duration = std::chrono::duration_cast<std::chrono::nanoseconds>(current_time_point - t0).count();
+    return static_cast<double>(duration) * 1e-9;
+  };
+
+  // Create and init perf results
+  auto perf_results = std::make_shared<ppc::core::PerfResults>();
+
+  // Create Perf analyzer
+  auto perf_analyzer = std::make_shared<ppc::core::Perf>(test_task_omp);
+  perf_analyzer->PipelineRun(perf_attr, perf_results);
+  ppc::core::Perf::PrintPerfStatistic(perf_results);
+  ASSERT_EQ(expected, out);
+}
+
+TEST(opolin_d_radix_batcher_sort_stl, test_task_run) {
+  int size = 500000;
+  std::vector<int> input;
+  std::vector<int> expected;
+  opolin_d_radix_batcher_sort_stl::GenDataRadixSort(size, input, expected);
+  std::vector<int> out(size, 0);
+  // Create TaskData
+  auto task_data_omp = std::make_shared<ppc::core::TaskData>();
+  task_data_omp->inputs.emplace_back(reinterpret_cast<uint8_t *>(input.data()));
+  task_data_omp->inputs_count.emplace_back(out.size());
+  task_data_omp->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+  task_data_omp->outputs_count.emplace_back(out.size());
+  // Create Task
+  auto test_task_omp = std::make_shared<opolin_d_radix_batcher_sort_stl::RadixBatcherSortTaskStl>(task_data_omp);
+  ASSERT_EQ(test_task_omp->Validation(), true);
+  test_task_omp->PreProcessing();
+  test_task_omp->Run();
+  test_task_omp->PostProcessing();
+  // Create Perf attributes
+  auto perf_attr = std::make_shared<ppc::core::PerfAttr>();
+  perf_attr->num_running = 10;
+  const auto t0 = std::chrono::high_resolution_clock::now();
+  perf_attr->current_timer = [&] {
+    auto current_time_point = std::chrono::high_resolution_clock::now();
+    auto duration = std::chrono::duration_cast<std::chrono::nanoseconds>(current_time_point - t0).count();
+    return static_cast<double>(duration) * 1e-9;
+  };
+  // Create and init perf results
+  auto perf_results = std::make_shared<ppc::core::PerfResults>();
+
+  // Create Perf analyzer
+  auto perf_analyzer = std::make_shared<ppc::core::Perf>(test_task_omp);
+  perf_analyzer->TaskRun(perf_attr, perf_results);
+  ppc::core::Perf::PrintPerfStatistic(perf_results);
+  ASSERT_EQ(expected, out);
+}

--- a/tasks/stl/opolin_d_radix_sort_batcher_merge/perf_tests/main.cpp
+++ b/tasks/stl/opolin_d_radix_sort_batcher_merge/perf_tests/main.cpp
@@ -32,7 +32,7 @@ void GenDataRadixSort(size_t size, std::vector<int> &vec, std::vector<int> &expe
 }  // namespace opolin_d_radix_batcher_sort_stl
 
 TEST(opolin_d_radix_batcher_sort_stl, test_pipeline_run) {
-  int size = 700000;
+  int size = 800000;
   std::vector<int> input;
   std::vector<int> expected;
   opolin_d_radix_batcher_sort_stl::GenDataRadixSort(size, input, expected);
@@ -70,7 +70,7 @@ TEST(opolin_d_radix_batcher_sort_stl, test_pipeline_run) {
 }
 
 TEST(opolin_d_radix_batcher_sort_stl, test_task_run) {
-  int size = 700000;
+  int size = 900000;
   std::vector<int> input;
   std::vector<int> expected;
   opolin_d_radix_batcher_sort_stl::GenDataRadixSort(size, input, expected);

--- a/tasks/stl/opolin_d_radix_sort_batcher_merge/src/ops_stl.cpp
+++ b/tasks/stl/opolin_d_radix_sort_batcher_merge/src/ops_stl.cpp
@@ -1,13 +1,12 @@
 #include "stl/opolin_d_radix_sort_batcher_merge/include/ops_stl.hpp"
 
 #include <algorithm>
+#include <atomic>
 #include <cmath>
 #include <cstddef>
 #include <cstdint>
 #include <functional>
 #include <iterator>
-#include <limits>
-#include <numeric>
 #include <thread>
 #include <vector>
 
@@ -40,19 +39,20 @@ bool opolin_d_radix_batcher_sort_stl::RadixBatcherSortTaskStl::RunImpl() {
     output_ = input_;
     return true;
   }
-  size_t unum_threads = static_cast<size_t>(num_threads);
-  unum_threads = std::min((size_t)unum_threads, (static_cast<size_t>(size_) + 1) / 2);
+  auto unum_threads = static_cast<size_t>(num_threads);
+  unum_threads = std::min(unum_threads, (static_cast<size_t>(size_) + 1) / 2);
   if (unum_threads == 0) {
     unum_threads = 1;
   }
-  ParallelProcessRange(size_, unum_threads, [this](size_t start, size_t end) {
+  ParallelProcessRange(static_cast<size_t>(size_), static_cast<unsigned int>(unum_threads),
+                       [this](size_t start, size_t end) {
     for (size_t i = start; i < end; ++i) {
       unsigned_data_[i] = IntToUnsigned(input_[i]);
     }
   });
 
-  size_t block_size = (size_ + unum_threads - 1) / unum_threads;
-  size_t actual_num_blocks = (size_ + block_size - 1) / block_size;
+  size_t block_size = (static_cast<size_t>(size_) + unum_threads - 1) / unum_threads;
+  size_t actual_num_blocks = (static_cast<size_t>(size_) + block_size - 1) / block_size;
   std::vector<std::function<void()>> sort_tasks;
   sort_tasks.reserve(actual_num_blocks);
   for (unsigned int i = 0; i < actual_num_blocks; ++i) {
@@ -60,14 +60,17 @@ bool opolin_d_radix_batcher_sort_stl::RadixBatcherSortTaskStl::RunImpl() {
     size_t end = std::min(start + block_size, static_cast<size_t>(size_));
     if (start < end) {
       sort_tasks.emplace_back(
-          [this, start, end]() { RadixSortLSD(unsigned_data_.begin() + start, unsigned_data_.begin() + end); });
+          [this, start, end]() { RadixSortLSD(unsigned_data_.begin() + static_cast<ptrdiff_t>(start),
+                                              unsigned_data_.begin() + static_cast<ptrdiff_t>(end)); });
     }
   }
   if (!sort_tasks.empty()) {
-    ParallelRunTasks(sort_tasks, unum_threads);
+    ParallelRunTasks(sort_tasks, static_cast<unsigned int>(unum_threads));
   }
-  IterativeOddEvenBlockMerge(unsigned_data_.begin(), unsigned_data_.end(), actual_num_blocks, block_size, unum_threads);
-  ParallelProcessRange(static_cast<size_t>(size_), unum_threads, [this](size_t start, size_t end) {
+  IterativeOddEvenBlockMerge(unsigned_data_.begin(), unsigned_data_.end(), actual_num_blocks, block_size,
+                             static_cast<unsigned int>(unum_threads));
+  ParallelProcessRange(static_cast<size_t>(size_), static_cast<unsigned int>(unum_threads),
+                       [this](size_t start, size_t end) {
     for (size_t i = start; i < end; ++i) {
       output_[i] = UnsignedToInt(unsigned_data_[i]);
     }
@@ -82,9 +85,9 @@ bool opolin_d_radix_batcher_sort_stl::RadixBatcherSortTaskStl::PostProcessingImp
   return true;
 }
 
-uint32_t opolin_d_radix_batcher_sort_stl::IntToUnsigned(int value) { return static_cast<uint32_t>(value) ^ (1u << 31); }
+uint32_t opolin_d_radix_batcher_sort_stl::IntToUnsigned(int value) { return static_cast<uint32_t>(value) ^ (1U << 31); }
 
-int opolin_d_radix_batcher_sort_stl::UnsignedToInt(uint32_t value) { return static_cast<int>(value ^ (1u << 31)); }
+int opolin_d_radix_batcher_sort_stl::UnsignedToInt(uint32_t value) { return static_cast<int>(value ^ (1U << 31)); }
 
 void opolin_d_radix_batcher_sort_stl::ParallelProcessRange(size_t total_size, unsigned int num_threads,
                                                            const std::function<void(size_t start, size_t end)>& func) {
@@ -128,7 +131,7 @@ void opolin_d_radix_batcher_sort_stl::ParallelRunTasks(const std::vector<std::fu
 
   for (unsigned int i = 0; i < actual_threads; ++i) {
     threads.emplace_back([&]() {
-      size_t current_task;
+      size_t current_task = 0;
       while ((current_task = task_idx.fetch_add(1, std::memory_order_relaxed)) < tasks.size()) {
         tasks[current_task]();
       }
@@ -147,28 +150,28 @@ void opolin_d_radix_batcher_sort_stl::RadixSortLSD(std::vector<uint32_t>::iterat
   if (n <= 1) {
     return;
   }
-  const int RADIX = 256;
-  const int NUM_PASSES = sizeof(uint32_t);
+  const int radix = 256;
+  const int num_passes = sizeof(uint32_t);
 
   std::vector<uint32_t> buffer(n);
-  std::vector<size_t> count(RADIX);
+  std::vector<size_t> count(radix);
 
-  for (int pass = 0; pass < NUM_PASSES; ++pass) {
+  for (int pass = 0; pass < num_passes; ++pass) {
     int shift = pass * 8;
-    std::fill(count.begin(), count.end(), 0);
+    std::ranges::fill(count, 0);
     for (auto it = begin; it != end; ++it) {
-      count[(*it >> shift) & (RADIX - 1)]++;
+      count[(*it >> shift) & (radix - 1)]++;
     }
     size_t cumulative_sum = 0;
-    for (size_t i = 0; i < RADIX; ++i) {
+    for (size_t i = 0; i < radix; ++i) {
       size_t current_count = count[i];
       count[i] = cumulative_sum;
       cumulative_sum += current_count;
     }
     for (auto it = begin; it != end; ++it) {
-      buffer[count[(*it >> shift) & (RADIX - 1)]++] = *it;
+      buffer[count[(*it >> shift) & (radix - 1)]++] = *it;
     }
-    std::copy(buffer.begin(), buffer.begin() + n, begin);
+    std::copy(buffer.begin(), buffer.begin() + static_cast<ptrdiff_t>(n), begin);
   }
 }
 
@@ -185,9 +188,9 @@ void opolin_d_radix_batcher_sort_stl::IterativeOddEvenBlockMerge(std::vector<uin
     std::vector<std::function<void()>> merge_tasks;
 
     for (size_t i = 0; i < n; i += 2 * current_merge_block_size) {
-      auto merge_begin = data_begin + i;
-      auto merge_mid = data_begin + std::min(i + current_merge_block_size, n);
-      auto merge_end = data_begin + std::min(i + 2 * current_merge_block_size, n);
+      auto merge_begin = data_begin + static_cast<ptrdiff_t>(i);
+      auto merge_mid = data_begin + static_cast<ptrdiff_t>(std::min(i + current_merge_block_size, n));
+      auto merge_end = data_begin + static_cast<ptrdiff_t>(std::min(i + (2 * current_merge_block_size), n));
       if (merge_mid < merge_end) {
         merge_tasks.emplace_back(
             [merge_begin, merge_mid, merge_end]() { std::inplace_merge(merge_begin, merge_mid, merge_end); });

--- a/tasks/stl/opolin_d_radix_sort_batcher_merge/src/ops_stl.cpp
+++ b/tasks/stl/opolin_d_radix_sort_batcher_merge/src/ops_stl.cpp
@@ -165,10 +165,10 @@ void opolin_d_radix_batcher_sort_stl::RadixSortLSD(std::vector<uint32_t>::iterat
       count[i] = cumulative_sum;
       cumulative_sum += current_count;
     }
-    for (auto it = std::make_reverse_iterator(end); it != std::make_reverse_iterator(begin); ++it) {
-      buffer[--count[(*it >> shift) & (RADIX - 1)]] = *it;
+    for (auto it = begin; it != end; ++it) {
+      buffer[count[(*it >> shift) & (RADIX - 1)]++] = *it;
     }
-    std::copy(buffer.begin(), buffer.end(), begin);
+    std::copy(buffer.begin(), buffer.begin() + n, begin);
   }
 }
 

--- a/tasks/stl/opolin_d_radix_sort_batcher_merge/src/ops_stl.cpp
+++ b/tasks/stl/opolin_d_radix_sort_batcher_merge/src/ops_stl.cpp
@@ -85,7 +85,7 @@ uint32_t opolin_d_radix_batcher_sort_stl::IntToUnsigned(int value) { return stat
 int opolin_d_radix_batcher_sort_stl::UnsignedToInt(uint32_t value) { return static_cast<int>(value ^ (1u << 31)); }
 
 void opolin_d_radix_batcher_sort_stl::ParallelProcessRange(size_t total_size, unsigned int num_threads,
-                                                   const std::function<void(size_t start, size_t end)>& func) {
+                                                           const std::function<void(size_t start, size_t end)>& func) {
   if (total_size == 0 || num_threads == 0) {
     return;
   }
@@ -112,7 +112,7 @@ void opolin_d_radix_batcher_sort_stl::ParallelProcessRange(size_t total_size, un
 }
 
 void opolin_d_radix_batcher_sort_stl::ParallelRunTasks(const std::vector<std::function<void()>>& tasks,
-                                               unsigned int num_threads) {
+                                                       unsigned int num_threads) {
   if (tasks.empty() || num_threads == 0) {
     return;
   }
@@ -139,7 +139,8 @@ void opolin_d_radix_batcher_sort_stl::ParallelRunTasks(const std::vector<std::fu
   }
 }
 
-void opolin_d_radix_batcher_sort_stl::RadixSortLSD(std::vector<uint32_t>::iterator begin, std::vector<uint32_t>::iterator end) {
+void opolin_d_radix_batcher_sort_stl::RadixSortLSD(std::vector<uint32_t>::iterator begin,
+                                                   std::vector<uint32_t>::iterator end) {
   size_t n = std::distance(begin, end);
   if (n <= 1) {
     return;
@@ -170,8 +171,8 @@ void opolin_d_radix_batcher_sort_stl::RadixSortLSD(std::vector<uint32_t>::iterat
 }
 
 void opolin_d_radix_batcher_sort_stl::IterativeOddEvenBlockMerge(std::vector<uint32_t>::iterator data_begin,
-                                                         std::vector<uint32_t>::iterator data_end, size_t num_blocks,
-                                                         unsigned int num_threads) {
+                                                                 std::vector<uint32_t>::iterator data_end,
+                                                                 size_t num_blocks, unsigned int num_threads) {
   size_t n = std::distance(data_begin, data_end);
   if (num_blocks <= 1 || n <= 1) {
     return;

--- a/tasks/stl/opolin_d_radix_sort_batcher_merge/src/ops_stl.cpp
+++ b/tasks/stl/opolin_d_radix_sort_batcher_merge/src/ops_stl.cpp
@@ -40,7 +40,7 @@ bool opolin_d_radix_batcher_sort_stl::RadixBatcherSortTaskStl::RunImpl() {
     return true;
   }
   size_t unum_threads = static_cast<size_t>(num_threads);
-  unum_threads = std::min((size_t)unum_threads, (size_ + 1) / 2);
+  unum_threads = std::min((size_t)unum_threads, (static_cast<size_t>(size_) + 1) / 2);
   if (unum_threads == 0) {
     unum_threads = 1;
   }
@@ -56,7 +56,7 @@ bool opolin_d_radix_batcher_sort_stl::RadixBatcherSortTaskStl::RunImpl() {
 
   for (unsigned int i = 0; i < actual_num_blocks; ++i) {
     size_t start = i * block_size;
-    size_t end = std::min(start + block_size, size_);
+    size_t end = std::min(start + block_size, static_cast<size_t>(size_));
     if (start < end) {
       sort_tasks.emplace_back(
           [this, start, end]() { RadixSortLSD(unsigned_data_.begin() + start, unsigned_data_.begin() + end); });
@@ -66,7 +66,7 @@ bool opolin_d_radix_batcher_sort_stl::RadixBatcherSortTaskStl::RunImpl() {
     ParallelRunTasks(sort_tasks, unum_threads);
   }
   IterativeOddEvenBlockMerge(unsigned_data_.begin(), unsigned_data_.end(), actual_num_blocks, unum_threads);
-  ParallelProcessRange(size_, unum_threads, [this](size_t start, size_t end) {
+  ParallelProcessRange(static_cast<size_t>(size_), unum_threads, [this](size_t start, size_t end) {
     for (size_t i = start; i < end; ++i) {
       output_[i] = UnsignedToInt(unsigned_data_[i]);
     }

--- a/tasks/stl/opolin_d_radix_sort_batcher_merge/src/ops_stl.cpp
+++ b/tasks/stl/opolin_d_radix_sort_batcher_merge/src/ops_stl.cpp
@@ -16,7 +16,7 @@ bool opolin_d_radix_batcher_sort_stl::RadixBatcherSortTaskStl::PreProcessingImpl
   auto* in_ptr = reinterpret_cast<int*>(task_data->inputs[0]);
   input_ = std::vector<int>(in_ptr, in_ptr + size_);
   unsigned int output_size = task_data->outputs_count[0];
-  output_ = std::vector<int>(output_size, 0);
+  output_ = std::vector<int>(output_size);
   unsigned_data_.resize(size_);
   return true;
 }
@@ -93,9 +93,6 @@ void opolin_d_radix_batcher_sort_stl::ParallelProcessRange(size_t total_size, un
     return;
   }
   unsigned int actual_threads = std::min(num_threads, static_cast<unsigned int>(total_size));
-  if (actual_threads == 0) {
-    actual_threads = 1;
-  }
   std::vector<std::thread> threads;
   threads.reserve(actual_threads);
   size_t block_size = (total_size + actual_threads - 1) / actual_threads;

--- a/tasks/stl/opolin_d_radix_sort_batcher_merge/src/ops_stl.cpp
+++ b/tasks/stl/opolin_d_radix_sort_batcher_merge/src/ops_stl.cpp
@@ -80,11 +80,11 @@ bool opolin_d_radix_batcher_sort_stl::RadixBatcherSortTaskStl::PostProcessingImp
   return true;
 }
 
-uint32_t RadixBatcherSortTaskStl::IntToUnsigned(int value) { return static_cast<uint32_t>(value) ^ (1u << 31); }
+uint32_t opolin_d_radix_batcher_sort_stl::IntToUnsigned(int value) { return static_cast<uint32_t>(value) ^ (1u << 31); }
 
-int RadixBatcherSortTaskStl::UnsignedToInt(uint32_t value) { return static_cast<int>(value ^ (1u << 31)); }
+int opolin_d_radix_batcher_sort_stl::UnsignedToInt(uint32_t value) { return static_cast<int>(value ^ (1u << 31)); }
 
-void RadixBatcherSortTaskStl::ParallelProcessRange(size_t total_size, unsigned int num_threads,
+void opolin_d_radix_batcher_sort_stl::ParallelProcessRange(size_t total_size, unsigned int num_threads,
                                                    const std::function<void(size_t start, size_t end)>& func) {
   if (total_size == 0 || num_threads == 0) {
     return;
@@ -111,7 +111,7 @@ void RadixBatcherSortTaskStl::ParallelProcessRange(size_t total_size, unsigned i
   }
 }
 
-void RadixBatcherSortTaskStl::ParallelRunTasks(const std::vector<std::function<void()>>& tasks,
+void opolin_d_radix_batcher_sort_stl::ParallelRunTasks(const std::vector<std::function<void()>>& tasks,
                                                unsigned int num_threads) {
   if (tasks.empty() || num_threads == 0) {
     return;
@@ -139,7 +139,7 @@ void RadixBatcherSortTaskStl::ParallelRunTasks(const std::vector<std::function<v
   }
 }
 
-void RadixBatcherSortTaskStl::RadixSortLSD(std::vector<uint32_t>::iterator begin, std::vector<uint32_t>::iterator end) {
+void opolin_d_radix_batcher_sort_stl::RadixSortLSD(std::vector<uint32_t>::iterator begin, std::vector<uint32_t>::iterator end) {
   size_t n = std::distance(begin, end);
   if (n <= 1) {
     return;
@@ -169,7 +169,7 @@ void RadixBatcherSortTaskStl::RadixSortLSD(std::vector<uint32_t>::iterator begin
   }
 }
 
-void RadixBatcherSortTaskStl::IterativeOddEvenBlockMerge(std::vector<uint32_t>::iterator data_begin,
+void opolin_d_radix_batcher_sort_stl::IterativeOddEvenBlockMerge(std::vector<uint32_t>::iterator data_begin,
                                                          std::vector<uint32_t>::iterator data_end, size_t num_blocks,
                                                          unsigned int num_threads) {
   size_t n = std::distance(data_begin, data_end);

--- a/tasks/stl/opolin_d_radix_sort_batcher_merge/src/ops_stl.cpp
+++ b/tasks/stl/opolin_d_radix_sort_batcher_merge/src/ops_stl.cpp
@@ -177,7 +177,7 @@ void opolin_d_radix_batcher_sort_stl::IterativeOddEvenBlockMerge(std::vector<uin
                                                                  size_t num_initial_blocks, size_t initial_block_size,
                                                                  unsigned int num_threads) {
   size_t n = std::distance(data_begin, data_end);
-  if (num_blocks <= 1 || n <= 1) {
+  if (num_initial_blocks <= 1 || n <= 1) {
     return;
   }
   size_t current_merge_block_size = initial_block_size;

--- a/tasks/stl/opolin_d_radix_sort_batcher_merge/src/ops_stl.cpp
+++ b/tasks/stl/opolin_d_radix_sort_batcher_merge/src/ops_stl.cpp
@@ -1,4 +1,4 @@
-#include "stl/opolin_d_radix_batcher_sort/include/ops_stl.hpp"
+#include "stl/opolin_d_radix_sort_batcher_merge/include/ops_stl.hpp"
 
 #include <algorithm>
 #include <cmath>

--- a/tasks/stl/opolin_d_radix_sort_batcher_merge/src/ops_stl.cpp
+++ b/tasks/stl/opolin_d_radix_sort_batcher_merge/src/ops_stl.cpp
@@ -1,0 +1,210 @@
+#include "stl/opolin_d_radix_batcher_sort/include/ops_stl.hpp"
+
+#include <algorithm>
+#include <cmath>
+#include <cstddef>
+#include <cstdint>
+#include <iterator>
+#include <limits>
+#include <thread>
+#include <vector>
+#include <functional>
+#include <numeric>
+
+#include "core/util/include/util.hpp"
+
+bool opolin_d_radix_batcher_sort_stl::RadixBatcherSortTaskStl::PreProcessingImpl() {
+  auto* in_ptr = reinterpret_cast<int*>(task_data->inputs[0]);
+  input_ = std::vector<int>(in_ptr, in_ptr + size_);
+  unsigned int output_size = task_data->outputs_count[0];
+  output_ = std::vector<int>(output_size, 0);
+  return true;
+}
+
+bool opolin_d_radix_batcher_sort_stl::RadixBatcherSortTaskStl::ValidationImpl() {
+  // Check equality of counts elements
+  size_ = static_cast<int>(task_data->inputs_count[0]);
+  if (size_ <= 0 || task_data->inputs.empty() || task_data->outputs.empty()) {
+    return false;
+  }
+  if (task_data->inputs[0] == nullptr || task_data->outputs[0] == nullptr) {
+    return false;
+  }
+  return task_data->inputs_count[0] == task_data->outputs_count[0];
+}
+
+bool opolin_d_radix_batcher_sort_stl::RadixBatcherSortTaskStl::RunImpl() {
+  int num_threads = ppc::util::GetPPCNumThreads();
+  if (size_ <= 1) {
+    output_ = input_;
+    return true;
+  }
+  num_threads = std::min((size_t)num_threads, (size_ + 1) / 2);
+  if (num_threads == 0) {
+    num_threads = 1;
+  }
+  ParallelProcessRange(size_, num_threads,
+    [this](size_t start, size_t end) {
+    for (size_t i = start; i < end; ++i) {
+      unsigned_data_[i] = IntToUnsigned(input_[i]);
+    }
+  });
+
+  size_t block_size = (size_ + num_threads - 1) / num_threads;
+  size_t actual_num_blocks = (size_ + block_size - 1) / block_size;
+  std::vector<std::function<void()>> sort_tasks;
+
+  for(unsigned int i = 0; i < actual_num_blocks; ++i) {
+    size_t start = i * block_size;
+    size_t end = std::min(start + block_size, size_);
+    if (start < end) {
+      sort_tasks.emplace_back([this, start, end](){
+        RadixSortLSD(unsigned_data_.begin() + start, unsigned_data_.begin() + end);
+      });
+    }
+  }
+  if (!sort_tasks.empty()){
+    ParallelRunTasks(sort_tasks, num_threads);
+  }
+  IterativeOddEvenBlockMerge(unsigned_data_.begin(), unsigned_data_.end(), actual_num_blocks, num_threads);
+  ParallelProcessRange(size_, num_threads,
+    [this](size_t start, size_t end) {
+    for (size_t i = start; i < end; ++i) {
+      output_[i] = UnsignedToInt(unsigned_data_[i]);
+    }
+  });
+  return true;
+}
+
+bool opolin_d_radix_batcher_sort_stl::RadixBatcherSortTaskStl::PostProcessingImpl() {
+  for (size_t i = 0; i < output_.size(); i++) {
+    reinterpret_cast<int*>(task_data->outputs[0])[i] = output_[i];
+  }
+  return true;
+}
+
+uint32_t RadixBatcherSortTaskStl::IntToUnsigned(int value) {
+  return static_cast<uint32_t>(value) ^ (1u << 31);
+}
+
+int RadixBatcherSortTaskStl::UnsignedToInt(uint32_t value) {
+  return static_cast<int>(value ^ (1u << 31));
+}
+
+void RadixBatcherSortTaskStl::ParallelProcessRange(size_t total_size, unsigned int num_threads,
+                                                   const std::function<void(size_t start, size_t end)>& func) {
+  if (total_size == 0 || num_threads == 0) {
+    return;
+  }
+  unsigned int actual_threads = std::min(num_threads, static_cast<unsigned int>(total_size));
+  if (actual_threads == 0) {
+    actual_threads = 1;
+  }
+  std::vector<std::thread> threads;
+  threads.reserve(actual_threads);
+  size_t block_size = (total_size + actual_threads - 1) / actual_threads;
+
+  for (unsigned int i = 0; i < actual_threads; ++i) {
+    size_t start = i * block_size;
+    size_t end = std::min(start + block_size, total_size);
+    if (start < end) {
+      threads.emplace_back(func, start, end);
+    }
+  }
+  for (auto& t : threads) {
+    if (t.joinable()) {
+      t.join();
+    }
+  }
+}
+
+void RadixBatcherSortTaskStl::ParallelRunTasks(const std::vector<std::function<void()>>& tasks, unsigned int num_threads) {
+  if (tasks.empty() || num_threads == 0) {
+    return;
+  }
+  unsigned int actual_threads = std::min(num_threads, static_cast<unsigned int>(tasks.size()));
+  if (actual_threads == 0) {
+    actual_threads = 1;
+  }
+  std::vector<std::thread> threads;
+  threads.reserve(actual_threads);
+  std::atomic<size_t> task_idx(0);
+
+  for (unsigned int i = 0; i < actual_threads; ++i) {
+    threads.emplace_back([&]() {
+      size_t current_task;
+      while ((current_task = task_idx.fetch_add(1, std::memory_order_relaxed)) < tasks.size()) {
+        tasks[current_task]();
+      }
+    });
+  }
+  for (auto& t : threads) {
+    if (t.joinable()) {
+      t.join();
+    }
+  }
+}
+
+void RadixBatcherSortTaskStl::RadixSortLSD(std::vector<uint32_t>::iterator begin, std::vector<uint32_t>::iterator end) {
+  size_t n = std::distance(begin, end);
+  if (n <= 1) {
+    return;
+  }
+  const int RADIX = 256;
+  const int NUM_PASSES = sizeof(uint32_t);
+
+  std::vector<uint32_t> buffer(n);
+  std::vector<size_t> count(RADIX);
+
+  for (int pass = 0; pass < NUM_PASSES; ++pass) {
+    int shift = pass * 8;
+    std::fill(count.begin(), count.end(), 0);
+    for (auto it = begin; it != end; ++it) {
+      count[(*it >> shift) & (RADIX - 1)]++;
+    }
+    size_t cumulative_sum = 0;
+    for (size_t i = 0; i < RADIX; ++i) {
+      size_t current_count = count[i];
+      count[i] = cumulative_sum;
+      cumulative_sum += current_count;
+    }
+    for (auto it = std::make_reverse_iterator(end); it != std::make_reverse_iterator(begin); ++it) {
+      buffer[--count[(*it >> shift) & (RADIX - 1)]] = *it;
+    }
+    std::copy(buffer.begin(), buffer.end(), begin);
+  }
+}
+
+void RadixBatcherSortTaskStl::IterativeOddEvenBlockMerge(std::vector<uint32_t>::iterator data_begin,
+                                                         std::vector<uint32_t>::iterator data_end,
+                                                         size_t num_blocks, unsigned int num_threads) {
+  size_t n = std::distance(data_begin, data_end);
+  if (num_blocks <= 1 || n <= 1) {
+    return;
+  }
+  std::vector<std::vector<uint32_t>::iterator> block_boundaries;
+  block_boundaries.push_back(data_begin);
+  size_t block_size = (n + num_blocks - 1) / num_blocks;
+  for (size_t i = 1; i < num_blocks; ++i) {
+    block_boundaries.push_back(data_begin + std::min(i * block_size, n));
+  }
+  block_boundaries.push_back(data_end);
+  for (size_t pass = 0; pass < num_blocks; ++pass) {
+    std::vector<std::function<void()>> merge_tasks;
+    size_t start_block_idx = (pass % 2 == 0) ? 0 : 1;
+    for (size_t i = start_block_idx; i + 1 < num_blocks; i += 2) {
+      auto merge_begin = block_boundaries[i];
+      auto merge_mid   = block_boundaries[i + 1];
+      auto merge_end   = block_boundaries[i + 2];
+      if (merge_mid >= merge_end) {
+        continue;
+      }
+      merge_tasks.emplace_back([merge_begin, merge_mid, merge_end]() {
+        std::inplace_merge(merge_begin, merge_mid, merge_end);
+      });
+    }
+    if (!merge_tasks.empty()) {
+      ParallelRunTasks(merge_tasks, num_threads);
+    }
+  }
+}

--- a/tasks/stl/opolin_d_radix_sort_batcher_merge/src/ops_stl.cpp
+++ b/tasks/stl/opolin_d_radix_sort_batcher_merge/src/ops_stl.cpp
@@ -18,6 +18,7 @@ bool opolin_d_radix_batcher_sort_stl::RadixBatcherSortTaskStl::PreProcessingImpl
   input_ = std::vector<int>(in_ptr, in_ptr + size_);
   unsigned int output_size = task_data->outputs_count[0];
   output_ = std::vector<int>(output_size, 0);
+  unsigned_data_.resize(size_);
   return true;
 }
 

--- a/tasks/stl/opolin_d_radix_sort_batcher_merge/src/ops_stl.cpp
+++ b/tasks/stl/opolin_d_radix_sort_batcher_merge/src/ops_stl.cpp
@@ -39,17 +39,18 @@ bool opolin_d_radix_batcher_sort_stl::RadixBatcherSortTaskStl::RunImpl() {
     output_ = input_;
     return true;
   }
-  num_threads = std::min((size_t)num_threads, (size_ + 1) / 2);
-  if (num_threads == 0) {
-    num_threads = 1;
+  size_t unum_threads = static_cast<size_t>(num_threads);
+  unum_threads = std::min((size_t)unum_threads, (size_ + 1) / 2);
+  if (unum_threads == 0) {
+    unum_threads = 1;
   }
-  ParallelProcessRange(size_, num_threads, [this](size_t start, size_t end) {
+  ParallelProcessRange(size_, unum_threads, [this](size_t start, size_t end) {
     for (size_t i = start; i < end; ++i) {
       unsigned_data_[i] = IntToUnsigned(input_[i]);
     }
   });
 
-  size_t block_size = (size_ + num_threads - 1) / num_threads;
+  size_t block_size = (size_ + unum_threads - 1) / unum_threads;
   size_t actual_num_blocks = (size_ + block_size - 1) / block_size;
   std::vector<std::function<void()>> sort_tasks;
 
@@ -62,10 +63,10 @@ bool opolin_d_radix_batcher_sort_stl::RadixBatcherSortTaskStl::RunImpl() {
     }
   }
   if (!sort_tasks.empty()) {
-    ParallelRunTasks(sort_tasks, num_threads);
+    ParallelRunTasks(sort_tasks, unum_threads);
   }
-  IterativeOddEvenBlockMerge(unsigned_data_.begin(), unsigned_data_.end(), actual_num_blocks, num_threads);
-  ParallelProcessRange(size_, num_threads, [this](size_t start, size_t end) {
+  IterativeOddEvenBlockMerge(unsigned_data_.begin(), unsigned_data_.end(), actual_num_blocks, unum_threads);
+  ParallelProcessRange(size_, unum_threads, [this](size_t start, size_t end) {
     for (size_t i = start; i < end; ++i) {
       output_[i] = UnsignedToInt(unsigned_data_[i]);
     }

--- a/tasks/stl/opolin_d_radix_sort_batcher_merge/src/ops_stl.cpp
+++ b/tasks/stl/opolin_d_radix_sort_batcher_merge/src/ops_stl.cpp
@@ -46,10 +46,10 @@ bool opolin_d_radix_batcher_sort_stl::RadixBatcherSortTaskStl::RunImpl() {
   }
   ParallelProcessRange(static_cast<size_t>(size_), static_cast<unsigned int>(unum_threads),
                        [this](size_t start, size_t end) {
-    for (size_t i = start; i < end; ++i) {
-      unsigned_data_[i] = IntToUnsigned(input_[i]);
-    }
-  });
+                         for (size_t i = start; i < end; ++i) {
+                           unsigned_data_[i] = IntToUnsigned(input_[i]);
+                         }
+                       });
 
   size_t block_size = (static_cast<size_t>(size_) + unum_threads - 1) / unum_threads;
   size_t actual_num_blocks = (static_cast<size_t>(size_) + block_size - 1) / block_size;
@@ -59,9 +59,10 @@ bool opolin_d_radix_batcher_sort_stl::RadixBatcherSortTaskStl::RunImpl() {
     size_t start = i * block_size;
     size_t end = std::min(start + block_size, static_cast<size_t>(size_));
     if (start < end) {
-      sort_tasks.emplace_back(
-          [this, start, end]() { RadixSortLSD(unsigned_data_.begin() + static_cast<ptrdiff_t>(start),
-                                              unsigned_data_.begin() + static_cast<ptrdiff_t>(end)); });
+      sort_tasks.emplace_back([this, start, end]() {
+        RadixSortLSD(unsigned_data_.begin() + static_cast<ptrdiff_t>(start),
+                     unsigned_data_.begin() + static_cast<ptrdiff_t>(end));
+      });
     }
   }
   if (!sort_tasks.empty()) {
@@ -71,10 +72,10 @@ bool opolin_d_radix_batcher_sort_stl::RadixBatcherSortTaskStl::RunImpl() {
                              static_cast<unsigned int>(unum_threads));
   ParallelProcessRange(static_cast<size_t>(size_), static_cast<unsigned int>(unum_threads),
                        [this](size_t start, size_t end) {
-    for (size_t i = start; i < end; ++i) {
-      output_[i] = UnsignedToInt(unsigned_data_[i]);
-    }
-  });
+                         for (size_t i = start; i < end; ++i) {
+                           output_[i] = UnsignedToInt(unsigned_data_[i]);
+                         }
+                       });
   return true;
 }
 

--- a/tasks/stl/opolin_d_radix_sort_batcher_merge/src/ops_stl.cpp
+++ b/tasks/stl/opolin_d_radix_sort_batcher_merge/src/ops_stl.cpp
@@ -189,9 +189,8 @@ void opolin_d_radix_batcher_sort_stl::IterativeOddEvenBlockMerge(std::vector<uin
       auto merge_mid = data_begin + std::min(i + current_merge_block_size, n);
       auto merge_end = data_begin + std::min(i + 2 * current_merge_block_size, n);
       if (merge_mid < merge_end) {
-        merge_tasks.emplace_back([merge_begin, merge_mid, merge_end]() {
-          std::inplace_merge(merge_begin, merge_mid, merge_end);
-        });
+        merge_tasks.emplace_back(
+            [merge_begin, merge_mid, merge_end]() { std::inplace_merge(merge_begin, merge_mid, merge_end); });
       }
     }
     if (!merge_tasks.empty()) {

--- a/tasks/stl/opolin_d_radix_sort_batcher_merge/src/ops_stl.cpp
+++ b/tasks/stl/opolin_d_radix_sort_batcher_merge/src/ops_stl.cpp
@@ -41,9 +41,6 @@ bool opolin_d_radix_batcher_sort_stl::RadixBatcherSortTaskStl::RunImpl() {
   }
   auto unum_threads = static_cast<size_t>(num_threads);
   unum_threads = std::min(unum_threads, (static_cast<size_t>(size_) + 1) / 2);
-  if (unum_threads == 0) {
-    unum_threads = 1;
-  }
   ParallelProcessRange(static_cast<size_t>(size_), static_cast<unsigned int>(unum_threads),
                        [this](size_t start, size_t end) {
                          for (size_t i = start; i < end; ++i) {
@@ -92,7 +89,7 @@ int opolin_d_radix_batcher_sort_stl::UnsignedToInt(uint32_t value) { return stat
 
 void opolin_d_radix_batcher_sort_stl::ParallelProcessRange(size_t total_size, unsigned int num_threads,
                                                            const std::function<void(size_t start, size_t end)>& func) {
-  if (total_size == 0 || num_threads == 0) {
+  if (total_size == 0) {
     return;
   }
   unsigned int actual_threads = std::min(num_threads, static_cast<unsigned int>(total_size));
@@ -119,7 +116,7 @@ void opolin_d_radix_batcher_sort_stl::ParallelProcessRange(size_t total_size, un
 
 void opolin_d_radix_batcher_sort_stl::ParallelRunTasks(const std::vector<std::function<void()>>& tasks,
                                                        unsigned int num_threads) {
-  if (tasks.empty() || num_threads == 0) {
+  if (tasks.empty()) {
     return;
   }
   unsigned int actual_threads = std::min(num_threads, static_cast<unsigned int>(tasks.size()));


### PR DESCRIPTION
1. Входной массив int преобразуется в uint32_t для корректной работы с отрицательными числами при поразрядной сортировке.
2. Массив делится на блоки. 
3. Каждый блок сортируется параллельно с использованием стандартной поразрядной сортировки для uint32_t (RadixSortLSD).
4. Массив снова переводится в int.
5. Применяется итеративное четно-нечетное слияние Бэтчера для отсортированных блоков.